### PR TITLE
Activate only legit images

### DIFF
--- a/verifier.go
+++ b/verifier.go
@@ -1,0 +1,53 @@
+/*
+ * container-feeder: import Linux container images delivered as RPMs
+ * Copyright 2017 SUSE LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// Verifies the file has not been tampered
+// The check is done using the information inside of the
+// RPM database.
+// Returns false if the file is not part of a RPM package.
+func Verify(file string) (bool, error) {
+	// figure out the name of the package shipping the file
+	// the `rpm` command exits with an error when the file is not managed by RPM
+	out, err := exec.Command(
+		"rpm",
+		"-qf",
+		file).Output()
+	if err != nil {
+		return false, err
+	}
+	rpm := strings.Trim(string(out[:]), "\n")
+
+	// verifies the whole rpm
+	// the `rpm` command exits with an error when the verification fails
+	_, err = exec.Command(
+		"rpm",
+		"--verify",
+		rpm).Output()
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/walker.go
+++ b/walker.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,16 +29,18 @@ import (
 // It's possible to list only the files matching a given extension,
 // remember to add the "." (eg: ".mp3")
 type Walker struct {
-	Root      string
-	Extension string // only list files with this extension
-	Files     []string
+	Root        string
+	Extension   string // only list files with this extension
+	Files       []string
+	VerifyFiles bool
 }
 
 func NewWalker(path, extension string) *Walker {
 	return &Walker{
-		Files:     []string{},
-		Extension: extension,
-		Root:      path,
+		Files:       []string{},
+		Extension:   extension,
+		Root:        path,
+		VerifyFiles: true,
 	}
 }
 
@@ -55,6 +58,12 @@ func (w *Walker) Scan(path string, f os.FileInfo, err error) error {
 
 		if w.Extension != "" && strings.ToLower(w.Extension) != strings.ToLower(filepath.Ext(path)) {
 			add = false
+		} else if w.VerifyFiles {
+			var verifyErr error
+			add, verifyErr = Verify(path)
+			if verifyErr != nil {
+				log.Printf("Ignoring file %s because verification failed %v", path, verifyErr)
+			}
 		}
 
 		if add {

--- a/walker_test.go
+++ b/walker_test.go
@@ -34,13 +34,13 @@ func TestWalkerFailVerificationFileNotManagedByRPM(t *testing.T) {
 }
 
 func TestWalkerWithVerificationEnabled(t *testing.T) {
-	topDir := "/usr/lib64/coreutils"
+	topDir := "/usr/share/zoneinfo"
 
 	if _, err := os.Stat(topDir); os.IsNotExist(err) {
 		t.Skipf("skipped: %s does not exist", topDir)
 	}
 
-	walker := NewWalker(topDir, ".so")
+	walker := NewWalker(topDir, ".tab")
 	if err := filepath.Walk(topDir, walker.Scan); err != nil {
 		t.Errorf("walker error: %v", err)
 	}

--- a/walker_test.go
+++ b/walker_test.go
@@ -9,18 +9,59 @@ import (
 	"testing"
 )
 
+func TestWalkerFailVerificationFileNotManagedByRPM(t *testing.T) {
+	topDir, err := ioutil.TempDir("", "test-walker")
+	if err != nil {
+		t.Errorf("error while creating test dir: %v", err)
+	}
+	// cleanup dir
+	defer os.RemoveAll(topDir)
+
+	f, err := os.Create(filepath.Join(topDir, "foo.mp3"))
+	err = f.Close()
+	if err != nil {
+		t.Errorf("error closing file: %v", err)
+	}
+
+	walker := NewWalker(topDir, ".mp3")
+	if err := filepath.Walk(topDir, walker.Scan); err != nil {
+		t.Errorf("walker error: %v", err)
+	}
+
+	if len(walker.Files) != 0 {
+		t.Error("Expected 0 matches")
+	}
+}
+
+func TestWalkerWithVerificationEnabled(t *testing.T) {
+	topDir := "/usr/lib64/coreutils"
+
+	if _, err := os.Stat(topDir); os.IsNotExist(err) {
+		t.Skipf("skipped: %s does not exist", topDir)
+	}
+
+	walker := NewWalker(topDir, ".so")
+	if err := filepath.Walk(topDir, walker.Scan); err != nil {
+		t.Errorf("walker error: %v", err)
+	}
+
+	if len(walker.Files) == 0 {
+		t.Error("Expected multiple matches")
+	}
+}
+
 func TestWalker(t *testing.T) {
 	topDir, err := ioutil.TempDir("", "test-walker")
 	if err != nil {
 		t.Errorf("error while creating test dir: %v", err)
 	}
+	// cleanup dir
+	defer os.RemoveAll(topDir)
+
 	subDir, err := ioutil.TempDir(topDir, "sub")
 	if err != nil {
 		t.Errorf("error while creating sub dir: %v", err)
 	}
-
-	// cleanup dir
-	defer os.RemoveAll(topDir)
 
 	expected := []string{}
 
@@ -62,6 +103,7 @@ func TestWalker(t *testing.T) {
 	}
 
 	walker := NewWalker(topDir, ".mp3")
+	walker.VerifyFiles = false
 	if err := filepath.Walk(topDir, walker.Scan); err != nil {
 		t.Errorf("walker error: %v", err)
 	}
@@ -89,6 +131,7 @@ func TestWalker(t *testing.T) {
 
 func TestWalkerNonExistingDirectory(t *testing.T) {
 	walker := NewWalker("/boom", ".mp3")
+	walker.VerifyFiles = false
 	if err := filepath.Walk("/boom", walker.Scan); err == nil {
 		t.Errorf("error was expected")
 	}


### PR DESCRIPTION
Ensure only the images shipped by RPMs that have not been tampered can be imported.