### PR TITLE
Implement importDockerImage function

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -99,7 +99,7 @@ func loadDockerImage(cli *client.Client, pathToImage string) (string, error) {
 
 	b, err := ioutil.ReadAll(ret.Body)
 
-	return string(b[:]), nil
+	return string(b), nil
 }
 
 // Import the specified image into docker with repotag
@@ -137,5 +137,5 @@ func importDockerImage(cli *client.Client, pathToImage string, repoTag string) (
 
 	b, err := ioutil.ReadAll(ret)
 
-	return string(b[:]), nil
+	return string(b), nil
 }

--- a/feeder.go
+++ b/feeder.go
@@ -92,7 +92,7 @@ func (f *Feeder) Import(path string) (FeederLoadResponse, error) {
 	}
 
 	for tag, file := range imagesToImport {
-		_, err := loadDockerImage(f.dockerClient, file)
+		_, err := importDockerImage(f.dockerClient, file, tag)
 		if err != nil {
 			res.FailedImports = append(
 				res.FailedImports,


### PR DESCRIPTION
Import the specified image into docker with repotag,
instead of loading image without repotag provided in
metadata.

Returns the message produced by the docker daemon.