### PR TITLE
fix docker version

### DIFF
--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -56,6 +56,7 @@ Source2:        %{name}.service
 BuildRequires:  golang-packaging systemd
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Requires:       docker
+Conflicts:      docker > 1.12.6
 Requires(post): %fillup_prereq
 
 %{?systemd_requires}


### PR DESCRIPTION
We are adding a conflict with docker > 1.12.6 to prevent accidentally
installing another docker which will be available in the containers
module.

This means that if we want to update docker, we need to update this
requirement.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>