### PR TITLE
Fix compatibility with docker 1.12.6

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -18,7 +18,6 @@
 package main
 
 import (
-	"encoding/json"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -84,10 +83,6 @@ func existingImages(cli *client.Client) ([]string, error) {
 	return tags, nil
 }
 
-type LoadResponseBody struct {
-	Stream string `json:"stream"`
-}
-
 // Loads the specified image into docker
 // Returns the image name loaded into the docker daemon
 func loadDockerImage(cli *client.Client, pathToImage string) (string, error) {
@@ -106,13 +101,8 @@ func loadDockerImage(cli *client.Client, pathToImage string) (string, error) {
 
 	b, err := ioutil.ReadAll(ret.Body)
 
-	// {"stream":"Loaded image: sles12/mariadb:10.0\n"}
-	var loadResponseBody LoadResponseBody
-	if err := json.Unmarshal(b[:], &loadResponseBody); err != nil {
-		return "", err
-	}
 	return strings.TrimSpace(strings.TrimPrefix(
-		loadResponseBody.Stream, "Loaded image:")), nil
+		string(b[:]), "Loaded image:")), nil
 }
 
 // Tags the specified docker image with the supplied tags


### PR DESCRIPTION
Docker 1.12.6 does not return a JSON payload in the ret.Body field
in 1.12.6, for now, lets fix compatibility with 1.12.6 and add
support for newer versions at a later date.