### PR TITLE
Compare all tags during import

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -110,9 +110,7 @@ func tagDockerImage(cli *client.Client, image string, tags []string) error {
 	for _, tag := range tags {
 		log.Debug("Tagging image: ", image, " with ", tag)
 
-		qualifiedTag := strings.Split(image, ":")[0] + ":" + tag
-
-		err := cli.ImageTag(context.Background(), image, qualifiedTag)
+		err := cli.ImageTag(context.Background(), image, tag)
 		if err != nil {
 			return err
 		}

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 
 	importResp, err := feeder.Import(*dir)
 	if err != nil {
-		log.Error("Something went wrong while imporing the images: %v\n", err)
+		log.Errorf("Something went wrong while imporing the images: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -51,13 +51,13 @@ func main() {
 		log.Info("Successfully imported the following images:")
 	}
 	for _, image := range importResp.SuccessfulImports {
-		log.Info("  - %s\n", image)
+		log.Infof("  - %s", image)
 	}
 
 	if len(importResp.FailedImports) > 0 {
 		log.Error("The following images failed to be imported:")
 	}
 	for _, failedImport := range importResp.FailedImports {
-		log.Error("  - %s with error: %v\n", failedImport.Image, failedImport.Error)
+		log.Errorf("  - %s with error: %v", failedImport.Image, failedImport.Error)
 	}
 }


### PR DESCRIPTION
Ensure all tags exist, rather than just the first tag, when deciding
if an image needs to be imported or not.

Additionally, fix logging formatting.