### PR TITLE
fix importing new tags

### DIFF
--- a/feeder.go
+++ b/feeder.go
@@ -93,7 +93,7 @@ func (f *Feeder) Import(path string) (FeederLoadResponse, error) {
 	}
 
 	for tag, file := range imagesToImport {
-		resp, err := loadDockerImage(f.dockerClient, file)
+		_, err := loadDockerImage(f.dockerClient, file)
 		if err != nil {
 			log.Warnf("Could not load image %s: %v", file, err)
 			res.FailedImports = append(
@@ -103,7 +103,7 @@ func (f *Feeder) Import(path string) (FeederLoadResponse, error) {
 					Error: err,
 				})
 		} else {
-			err = tagDockerImage(f.dockerClient, resp, imagesToImportTags[tag])
+			err = tagDockerImage(f.dockerClient, tag, imagesToImportTags[tag])
 			if err != nil {
 				log.Warnf("Could not tag image %s: %v", file, err)
 				res.FailedImports = append(


### PR DESCRIPTION
We were using the "response" of the image creation called as image name.
This was working when there was no previous image, but when that is the
case, response contains a message error.

This commit fixes it

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>
(cherry picked from commit a7844f96d2f19517700204560d474eb20cde9b5e)