### PR TITLE
update packaging

### DIFF
--- a/packaging/suse/sources/container-feeder-rpmlintrc
+++ b/packaging/suse/sources/container-feeder-rpmlintrc
@@ -1,0 +1,3 @@
+addFilter (".* W: explicit-lib-dependency libcontainers-common")
+addFilter (".* W: explicit-lib-dependency libcontainers-image")
+addFilter (".* W: explicit-lib-dependency libcontainers-storage")


### PR DESCRIPTION
Update the make_spec.sh spec-file generation template and add the
remaining sources to adhere to the lastet changes introduced by commit
78c810dba49f ("add crio support").

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>