### PR TITLE
add whitelist support

### DIFF
--- a/container-feeder.json
+++ b/container-feeder.json
@@ -1,3 +1,4 @@
 {
-	"feeder-target": "docker"
+	"feeder-target": "docker",
+	"whitelist": []
 }

--- a/feeder/feeder_test.go
+++ b/feeder/feeder_test.go
@@ -1,0 +1,116 @@
+/*
+ * container-feeder: import Linux container images delivered as RPMs
+ * Copyright 2018 SUSE LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feeder
+
+import (
+	"testing"
+)
+
+
+func TestNormalizeNameTag(t *testing.T) {
+	var name, tag string
+	var err error
+
+	name, tag, err = normalizeNameTag("opensuse:latest")
+	if err != nil || name != "docker.io/library/opensuse" || tag != "latest" {
+		t.Errorf("unexpected output: name: %s, tag: %s, err: %v", name, tag, err)
+	}
+
+	name, tag, err = normalizeNameTag("opensuse/with/path:latest")
+	if err != nil || name != "docker.io/opensuse/with/path" || tag != "latest" {
+		t.Errorf("unexpected output: name: %s, tag: %s, err: %v", name, tag, err)
+	}
+
+	name, tag, err = normalizeNameTag("registry.suse.com/sles12/foo:bar")
+	if err != nil || name != "registry.suse.com/sles12/foo" || tag != "bar" {
+		t.Errorf("unexpected output: name: %s, tag: %s, err: %v", name, tag, err)
+	}
+
+	name, tag, err = normalizeNameTag("localhost:5000/notag")
+	if err != nil || name != "localhost:5000/notag" || tag != "" {
+		t.Errorf("unexpected output: name: %s, tag: %s, err: %v", name, tag, err)
+	}
+
+	name, tag, err = normalizeNameTag("invalidtag:")
+	if err == nil {
+		t.Errorf("unexpected output: name: %s, tag: %s, err: %v", name, tag, err)
+	}
+}
+
+func TestParseWhitelist(t *testing.T) {
+	var list, res []string
+	var err error
+
+	list = []string{"opensuse", "opensuse/amd64"}
+	res, err = parseWhitelist(list)
+	if err != nil {
+		t.Error("unexpected error: %v", err)
+	}
+	if res[0] != "docker.io/library/opensuse" {
+		t.Error("unexpected list element: %s", res[0])
+	}
+
+	list = []string{"registry.suse.com/coolimage:withtag"}
+	_, err = parseWhitelist(list)
+	if err == nil {
+		t.Error("error expected but not received")
+	}
+}
+
+func TestIsWhitelisted(t *testing.T) {
+	whitelist := []string{"docker.io/library/opensuse", "docker.io/sles12/with/a/path"}
+	var err error
+	var whitelisted bool
+
+	whitelisted, err = isWhitelisted("opensuse:12345", whitelist)
+	if err != nil {
+		t.Error("Whitelisting should not have failed")
+	}
+	if whitelisted != true {
+		t.Error("Image should be whitelisted")
+	}
+
+	whitelisted, err = isWhitelisted("sles12/with/a/path:awesometag", whitelist)
+	if err != nil {
+		t.Error("Whitelisting should not have failed")
+	}
+	if whitelisted != true {
+		t.Error("Image should be whitelisted")
+	}
+
+	whitelisted, err = isWhitelisted("sles12/with/another/path:awesometag", whitelist)
+	if err != nil {
+		t.Error("Whitelisting should not have failed")
+	}
+	if whitelisted != false {
+		t.Error("Image should not be whitelisted")
+	}
+
+	whitelisted, err = isWhitelisted("un:expected:format", whitelist)
+	if err == nil {
+		t.Error("Whitelisting should not have failed")
+	}
+
+	whitelisted, err = isWhitelisted("no:whitelist", []string{})
+	if err != nil {
+		t.Error("Whitelisting should not have failed")
+	}
+	if whitelisted != true {
+		t.Error("Image should be whitelisted")
+	}
+}


### PR DESCRIPTION
Depending on the cluster-role and use-case of a machine, only a subset
of container images must be loaded.  Add whitelist support for image
loading to container-feeder in order to avoid redundant loading and to
ultimately speed things up.

The whitelist can be specified via the `/etc/container-feeder.json`
config.  The `whitelist` field in the config is an array of strings,
each representing an image name (e.g., `opensuse/tumbleweed`).  Hence,
the whitelist filtering is image-name based and ignores tags.  If the
whitelist is empty, no filtering will be applied.

From the code perspective, the change required to break the Feeder into
a concrete type and an interface.

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>
feature#crio