### PR TITLE
crio_feeder: speedup image loading

### DIFF
--- a/feeder/feeder.go
+++ b/feeder/feeder.go
@@ -18,10 +18,12 @@
 package feeder
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 
 	"github.com/containers/image/docker/reference"
@@ -359,4 +361,25 @@ func repotagFromRPMFile(file string) (string, []string, string, error) {
 	}
 
 	return repotag, repotags, image, nil
+}
+
+// runCommand executes the program specified in args with env and writes to
+// stdout.
+func runCommand(args []string, env string, stdout *os.File) error {
+	var cmd *exec.Cmd
+	var serr bytes.Buffer
+
+	log.Debugf("runCommand(args=%s, env=%s)", args, env)
+
+	cmd = exec.Command(args[0], args[1:]...)
+	cmd.Stdout = stdout
+	cmd.Stderr = &serr
+	cmd.Env = []string{env}
+
+	err := cmd.Run()
+	if err != nil {
+		log.Debugf("Error executing command: %s", serr.String())
+		return fmt.Errorf("error running command: %s", err.Error())
+	}
+	return nil
 }

--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -78,6 +78,7 @@ Requires:       docker-kubic
 Requires:       libcontainers-common
 Requires:       libcontainers-image
 Requires:       libcontainers-storage
+Requires:       xz
 Requires(post): %fillup_prereq
 %{?systemd_requires}
 %{go_nostrip}


### PR DESCRIPTION
Shell out to /usr/bin/unxz to uncompress the container images instead of
using the golang xz library to speed things up.  Preliminary experiments
have shown speed improvements from nearly 18 seconds down to 5 seconds
per image load.

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>
feature#crio