### PR TITLE
[3.0] Fix func normalizeNameTag() when image <none>:<none>, bsc#1107228

### DIFF
--- a/feeder/feeder.go
+++ b/feeder/feeder.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 
 	"github.com/containers/image/docker/reference"
 
@@ -216,6 +217,9 @@ func Import(path string) (FeederLoadResponse, error) {
 
 //normalizeNameTag split the image into it's name and tag.
 func normalizeNameTag(image string) (string, string, error) {
+	// Remove illegal characters when image is "<none>:<none>"
+	re := regexp.MustCompile(`<|>`)
+	image = re.ReplaceAllString(image, "")
 	ref, err := reference.ParseNormalizedNamed(image)
 	if err != nil {
 		return "", "", fmt.Errorf("error parsing image name '%s': %v", image, err)

--- a/feeder/feeder_test.go
+++ b/feeder/feeder_test.go
@@ -45,6 +45,11 @@ func TestNormalizeNameTag(t *testing.T) {
 		t.Errorf("unexpected output: name: %s, tag: %s, err: %v", name, tag, err)
 	}
 
+	name, tag, err = normalizeNameTag("<none>:<none>")
+	if err != nil || name != "docker.io/library/none" || tag != "none" {
+		t.Errorf("unexpected output: name: %s, tag: %s, err: %v", name, tag, err)
+	}
+
 	name, tag, err = normalizeNameTag("invalidtag:")
 	if err == nil {
 		t.Errorf("unexpected output: name: %s, tag: %s, err: %v", name, tag, err)


### PR DESCRIPTION
(cherry picked from commit 37fa81636dc609165f484691244cf0c27563e75b)